### PR TITLE
Fix Microsoft license misspelling

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Micorosft Corporation
+Copyright (c) 2015 Microsoft Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/examples/sinatra-multiple-providers-app/app.rb
+++ b/examples/sinatra-multiple-providers-app/app.rb
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2015 Micorosft Corporation
+# Copyright (c) 2015 Microsoft Corporation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/examples/sinatra-multiple-providers-app/config.ru
+++ b/examples/sinatra-multiple-providers-app/config.ru
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2015 Micorosft Corporation
+# Copyright (c) 2015 Microsoft Corporation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/omniauth-azure-activedirectory.rb
+++ b/lib/omniauth-azure-activedirectory.rb
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2015 Micorosft Corporation
+# Copyright (c) 2015 Microsoft Corporation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/omniauth/azure_activedirectory.rb
+++ b/lib/omniauth/azure_activedirectory.rb
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2015 Micorosft Corporation
+# Copyright (c) 2015 Microsoft Corporation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/omniauth/azure_activedirectory/version.rb
+++ b/lib/omniauth/azure_activedirectory/version.rb
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2015 Micorosft Corporation
+# Copyright (c) 2015 Microsoft Corporation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/omniauth/strategies/azure_activedirectory.rb
+++ b/lib/omniauth/strategies/azure_activedirectory.rb
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2015 Micorosft Corporation
+# Copyright (c) 2015 Microsoft Corporation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/spec/omniauth/strategies/azure_activedirectory_spec.rb
+++ b/spec/omniauth/strategies/azure_activedirectory_spec.rb
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2015 Micorosft Corporation
+# Copyright (c) 2015 Microsoft Corporation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2015 Micorosft Corporation
+# Copyright (c) 2015 Microsoft Corporation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This commit fixes a misspelling of the Microsoft company name.
