### PR TITLE
Authentication errors should redirect to /auth/failure (similar to #18)

### DIFF
--- a/examples/rails-todo-list-app/config/routes.rb
+++ b/examples/rails-todo-list-app/config/routes.rb
@@ -18,5 +18,5 @@ Rails.application.routes.draw do
 
   # This is where we are redirected if OmniAuth fails to authenticate the user.
   # user
-  match '/auth/:provider/failure', to: redirect('/'), via: [:get, :post]
+  match '/auth/failure', to: redirect('/'), via: [:get, :post]
 end

--- a/examples/sinatra-multiple-providers-app/app.rb
+++ b/examples/sinatra-multiple-providers-app/app.rb
@@ -45,7 +45,7 @@ end
 end
 
 %w(get post).each do |method|
-  send(method, '/auth/:provider/failure') do
+  send(method, '/auth/failure') do
     "Aw shucks, we couldn't verify your identity!"
   end
 end

--- a/lib/omniauth/strategies/azure_activedirectory.rb
+++ b/lib/omniauth/strategies/azure_activedirectory.rb
@@ -85,7 +85,7 @@ module OmniAuth
       # credentials at the authorization endpoint.
       def callback_phase
         error = request.params['error_reason'] || request.params['error']
-        fail(OAuthError, error) if error
+        return fail!(error) if error
         @session_state = request.params['session_state']
         @id_token = request.params['id_token']
         @code = request.params['code']


### PR DESCRIPTION
Exactly like the solution in #18 but I went ahead and made change styling changes suggested by @phongsi and also updated the example applications to show the default OmniAuth failure path of `/auth/failure` instead of `/auth/:provider/failure`.
