### PR TITLE
Suggestion - rename classes to follow Rails conventions

### DIFF
--- a/lib/omniauth/azure_activedirectory/version.rb
+++ b/lib/omniauth/azure_activedirectory/version.rb
@@ -22,7 +22,7 @@
 
 module OmniAuth
   # The release version.
-  module AzureActiveDirectory
+  module AzureActivedirectory
     VERSION = '1.0.0'
   end
 end

--- a/lib/omniauth/strategies/azure_activedirectory.rb
+++ b/lib/omniauth/strategies/azure_activedirectory.rb
@@ -28,8 +28,8 @@ require 'securerandom'
 module OmniAuth
   module Strategies
     # A strategy for authentication against Azure Active Directory.
-    class AzureActiveDirectory
-      include OmniAuth::AzureActiveDirectory
+    class AzureActivedirectory
+      include OmniAuth::AzureActivedirectory
       include OmniAuth::Strategy
 
       class OAuthError < StandardError; end

--- a/lib/omniauth/strategies/azure_activedirectory.rb
+++ b/lib/omniauth/strategies/azure_activedirectory.rb
@@ -325,5 +325,3 @@ module OmniAuth
     end
   end
 end
-
-OmniAuth.config.add_camelization 'azure_activedirectory', 'AzureActiveDirectory'

--- a/omniauth-azure-activedirectory.gemspec
+++ b/omniauth-azure-activedirectory.gemspec
@@ -3,7 +3,7 @@ require 'omniauth/azure_activedirectory/version'
 
 Gem::Specification.new do |s|
   s.name            = 'omniauth-azure-activedirectory'
-  s.version         = OmniAuth::AzureActiveDirectory::VERSION
+  s.version         = OmniAuth::AzureActivedirectory::VERSION
   s.author          = 'Microsoft Corporation'
   s.email           = 'nugetaad@microsoft.com'
   s.summary         = 'Azure Active Directory strategy for OmniAuth'

--- a/spec/omniauth/strategies/azure_activedirectory_spec.rb
+++ b/spec/omniauth/strategies/azure_activedirectory_spec.rb
@@ -25,7 +25,7 @@ require 'omniauth-azure-activedirectory'
 
 # This was fairly awkward to test. I've stubbed every endpoint and am simulating
 # the state of the request. Especially large strings are stored in fixtures.
-describe OmniAuth::Strategies::AzureActiveDirectory do
+describe OmniAuth::Strategies::AzureActivedirectory do
   let(:app) { -> _ { [200, {}, ['Hello world.']] } }
   let(:x5c) { File.read(File.expand_path('../../../fixtures/x5c.txt', __FILE__)) }
 


### PR DESCRIPTION
Originally I've started this PR because I thought it is causing Devise gem not able to implement omniauth-azure-activedirectory due to collision of naming convention. Then I found out that it was due to something else (I will link step by step manual once I finish writing it )

So anyway I'll leave this PR for discussion in here. I'm not necessary fighting for this solution, it may (or may not)  break some already existing Apps using this gem but still worth considering something for v 2.0.0 of this gem.


 