### PR TITLE
Fix Travis errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
 
 rvm:
-  - 2.1
-  - 2.2
+  - 2.2.2
+  - 2.3
+  - 2.4
 
 script: bundle exec rake spec

--- a/omniauth-azure-activedirectory.gemspec
+++ b/omniauth-azure-activedirectory.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.3'
   s.add_development_dependency 'rubocop', '~> 0.32'
   s.add_development_dependency 'simplecov', '~> 0.10'
-  s.add_development_dependency 'webmock', '~> 1.21'
+  s.add_development_dependency 'webmock', '~> 3.0.0'
 end


### PR DESCRIPTION
Remove Ruby 2.1 from Travis since it's not supported any more
Use Ruby 2.2.2 to fix errors with rack
Add Ruby 2.3 and 2.4
Also use webmock 3.0 to fix problems with Ruby 2.4