### PR TITLE
Use fail! in callback_phase

### DIFF
--- a/lib/omniauth/azure_activedirectory/version.rb
+++ b/lib/omniauth/azure_activedirectory/version.rb
@@ -23,6 +23,6 @@
 module OmniAuth
   # The release version.
   module AzureActiveDirectory
-    VERSION = '1.0.0'
+    VERSION = '1.0.0-cz-1'
   end
 end

--- a/lib/omniauth/strategies/azure_activedirectory.rb
+++ b/lib/omniauth/strategies/azure_activedirectory.rb
@@ -85,7 +85,7 @@ module OmniAuth
       # credentials at the authorization endpoint.
       def callback_phase
         error = request.params['error_reason'] || request.params['error']
-        fail(OAuthError, error) if error
+        fail!(OAuthError, error) if error
         @session_state = request.params['session_state']
         @id_token = request.params['id_token']
         @code = request.params['code']


### PR DESCRIPTION
The omniauth library provides a fail! method to hook a failure in a
plugin, which the azure plugin isn't using.

https://github.com/AzureAD/omniauth-azure-activedirectory/issues/17