### PR TITLE
Fixed missing net/http

### DIFF
--- a/lib/omniauth/strategies/azure_activedirectory.rb
+++ b/lib/omniauth/strategies/azure_activedirectory.rb
@@ -24,6 +24,7 @@ require 'jwt'
 require 'omniauth'
 require 'openssl'
 require 'securerandom'
+require 'net/http'
 
 module OmniAuth
   module Strategies


### PR DESCRIPTION
## The Issue

The `azure_activedirectory.rb` strategy in this project does not include the `net/http` library but uses it heavily.

On Ubuntu 16+, Ruby 2.5, authentication attempts fail because of this missing requirement.

```
NameError (uninitialized constant Net):

omniauth-azure-activedirectory (1.0.0) lib/omniauth/strategies/azure_activedirectory.rb:169:in `fetch_openid_config'
omniauth-azure-activedirectory (1.0.0) lib/omniauth/strategies/azure_activedirectory.rb:190:in `openid_config'
omniauth-azure-activedirectory (1.0.0) lib/omniauth/strategies/azure_activedirectory.rb:105:in `authorize_endpoint_url'
omniauth-azure-activedirectory (1.0.0) lib/omniauth/strategies/azure_activedirectory.rb:79:in `request_phase'
omniauth (1.8.1) lib/omniauth/strategy.rb:224:in `request_call'
omniauth (1.8.1) lib/omniauth/strategy.rb:187:in `call!'
omniauth (1.8.1) lib/omniauth/strategy.rb:168:in `call'
```

## The solution

I've simply included `net/http` in the Azure Active Directory strategy to resolve this.

I've tested authentication is working normally after this change. 