### PR TITLE
Update gemspec webmock and omniauth ver

### DIFF
--- a/lib/omniauth/azure_activedirectory/version.rb
+++ b/lib/omniauth/azure_activedirectory/version.rb
@@ -23,6 +23,6 @@
 module OmniAuth
   # The release version.
   module AzureActiveDirectory
-    VERSION = '1.0.0'
+    VERSION = '1.0.1'
   end
 end

--- a/omniauth-azure-activedirectory.gemspec
+++ b/omniauth-azure-activedirectory.gemspec
@@ -15,11 +15,11 @@ Gem::Specification.new do |s|
   s.require_paths   = ['lib']
 
   s.add_runtime_dependency 'jwt', '~> 1.5'
-  s.add_runtime_dependency 'omniauth', '~> 1.1'
+  s.add_runtime_dependency 'omniauth', '~> 1.9.1'
 
   s.add_development_dependency 'rake', '~> 10.4'
   s.add_development_dependency 'rspec', '~> 3.3'
   s.add_development_dependency 'rubocop', '~> 0.32'
   s.add_development_dependency 'simplecov', '~> 0.10'
-  s.add_development_dependency 'webmock', '~> 1.21'
+  s.add_development_dependency 'webmock', '~> 3.8.3'
 end


### PR DESCRIPTION
Old versions of webmock and omniauth was causing errors in `bundle exec rspec`
With new version test passes successfully