### PR TITLE
Cl2-5942 - Remove query params from callback url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+As this is an unoficial fork, no actual Gems are released for any version.
+
+## [1.1.0] - 2019-01-05
+
+### Added
+- Support for the Azure v2.0 AD openidconnect endpoint
+- option to run a single provider for multiple AD tenants
+- support for password reset requests
+
+### Changed
+- Updated JWT dependency to ~> 2.0
+
+### Fixed
+- use a configured on\_failure error handler instead of always raising
+  exceptions in callback\_phase
+
+

--- a/lib/omniauth/azure_activedirectory/version.rb
+++ b/lib/omniauth/azure_activedirectory/version.rb
@@ -23,6 +23,6 @@
 module OmniAuth
   # The release version.
   module AzureActiveDirectory
-    VERSION = '1.0.0'
+    VERSION = '1.1.0'
   end
 end

--- a/lib/omniauth/strategies/azure_activedirectory.rb
+++ b/lib/omniauth/strategies/azure_activedirectory.rb
@@ -159,9 +159,7 @@ module OmniAuth
           nonce: new_nonce
         }.to_a
         # preserve existing URL params
-        if uri.query
-          params += URI.decode_www_form(String(uri.query))
-        end
+        params += URI.decode_www_form(String(uri.query)) if uri.query
         uri.query = URI.encode_www_form(params)
         uri.to_s
       end
@@ -184,6 +182,10 @@ module OmniAuth
 
       def redirect_uri
         options[:redirect_uri] || callback_url
+      end
+
+      def callback_url
+        full_host + script_name + callback_path
       end
 
       ##

--- a/lib/omniauth/strategies/azure_activedirectory.rb
+++ b/lib/omniauth/strategies/azure_activedirectory.rb
@@ -111,8 +111,10 @@ module OmniAuth
       # the authentication process. It is called after the user enters
       # credentials at the authorization endpoint.
       def callback_phase
-        error = request.params['error_reason'] || request.params['error']
-        fail(OAuthError, error) if error
+        if error = request.params['error_reason'] || request.params['error']
+          fail! error, OAuthError
+          return
+        end
         @session_state = request.params['session_state']
         @id_token = request.params['id_token']
         @code = request.params['code']

--- a/lib/omniauth/strategies/azure_activedirectory.rb
+++ b/lib/omniauth/strategies/azure_activedirectory.rb
@@ -159,7 +159,7 @@ module OmniAuth
           nonce: new_nonce
         }.to_a
         # preserve existing URL params
-        if uri.query.present?
+        if uri.query
           params += URI.decode_www_form(String(uri.query))
         end
         uri.query = URI.encode_www_form(params)

--- a/lib/omniauth/strategies/azure_activedirectory.rb
+++ b/lib/omniauth/strategies/azure_activedirectory.rb
@@ -359,7 +359,7 @@ module OmniAuth
             # The key also contains other fields, such as n and e, that are
             # redundant. x5c is sufficient to verify the id token.
             if x5c = key['x5c'] and !x5c.empty?
-              OpenSSL::X509::Certificate.new(JWT.base64url_decode(x5c.first)).public_key
+              OpenSSL::X509::Certificate.new(JWT::Decode.base64url_decode(x5c.first)).public_key
             # no x5c, so we resort to e and n
             elsif exp = key['e'] and mod = key['n']
               key = OpenSSL::PKey::RSA.new
@@ -405,7 +405,7 @@ module OmniAuth
         # This maps RS256 -> sha256, ES384 -> sha384, etc.
         algorithm = (header['alg'] || 'RS256').sub(/RS|ES|HS/, 'sha')
         full_hash = OpenSSL::Digest.new(algorithm).digest code
-        c_hash = JWT.base64url_encode full_hash[0..full_hash.length / 2 - 1]
+        c_hash = JWT::Encode.base64url_encode full_hash[0..full_hash.length / 2 - 1]
         return if c_hash == claims['c_hash']
         fail JWT::VerificationError,
              'c_hash in id token does not match auth code.'

--- a/lib/omniauth/strategies/azure_activedirectory.rb
+++ b/lib/omniauth/strategies/azure_activedirectory.rb
@@ -32,8 +32,6 @@ module OmniAuth
       include OmniAuth::AzureActiveDirectory
       include OmniAuth::Strategy
 
-      class OAuthError < StandardError; end
-
       ##
       # The client id (key) and tenant must be configured when the OmniAuth
       # middleware is installed. Example:
@@ -112,7 +110,7 @@ module OmniAuth
       # credentials at the authorization endpoint.
       def callback_phase
         if error = request.params['error_reason'] || request.params['error']
-          fail! error, OAuthError
+          fail! error # invokes the configured on_failure handler
           return
         end
         @session_state = request.params['session_state']

--- a/omniauth-azure-activedirectory.gemspec
+++ b/omniauth-azure-activedirectory.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files           = `git ls-files`.split("\n")
   s.require_paths   = ['lib']
 
-  s.add_runtime_dependency 'jwt', '~> 1.5'
+  s.add_runtime_dependency 'jwt', '~> 2.1'
   s.add_runtime_dependency 'omniauth', '~> 1.1'
 
   s.add_development_dependency 'rake', '~> 10.4'

--- a/omniauth-azure-activedirectory.gemspec
+++ b/omniauth-azure-activedirectory.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files           = `git ls-files`.split("\n")
   s.require_paths   = ['lib']
 
-  s.add_runtime_dependency 'jwt', '~> 1.5'
+  s.add_runtime_dependency 'jwt', '~> 2.0'
   s.add_runtime_dependency 'omniauth', '~> 1.1'
 
   s.add_development_dependency 'rake', '~> 10.4'

--- a/spec/omniauth/strategies/azure_activedirectory_spec.rb
+++ b/spec/omniauth/strategies/azure_activedirectory_spec.rb
@@ -127,7 +127,8 @@ describe OmniAuth::Strategies::AzureActiveDirectory do
       #   { 'iss' => 'https://sts.imposter.net/bunch-of-random-chars', ... }
       #
       let(:id_token) { File.read(File.expand_path('../../../fixtures/id_token_bad_issuer.txt', __FILE__)) }
-      it { is_expected.to raise_error JWT::InvalidIssuerError }
+      #it { is_expected.to raise_error JWT::InvalidIssuerError }
+      it { is_expected.to raise_error JWT::VerificationError }
     end
 
     context 'with an invalid audience' do
@@ -135,7 +136,8 @@ describe OmniAuth::Strategies::AzureActiveDirectory do
       #   { 'aud' => 'not the client id', ... }
       #
       let(:id_token) { File.read(File.expand_path('../../../fixtures/id_token_bad_audience.txt', __FILE__)) }
-      it { is_expected.to raise_error JWT::InvalidAudError }
+      #it { is_expected.to raise_error JWT::InvalidAudError }
+      it { is_expected.to raise_error JWT::VerificationError }
     end
 
     context 'with a non-matching nonce' do


### PR DESCRIPTION
Changed `callback_url` from the [omniauth gem](https://github.com/omniauth/omniauth/blob/c95a5a0a50e012b3ba34401a19d589fcdf02afdf/lib/omniauth/strategy.rb#L443) default:

```ruby
def callback_url
  full_host + script_name + callback_path + query_string
end
```

to:

```ruby
def callback_url
  full_host + script_name + callback_path
end
```